### PR TITLE
Change liveliness policy types to reflect actual settings

### DIFF
--- a/rmw/include/rmw/qos_profiles.h
+++ b/rmw/include/rmw/qos_profiles.h
@@ -22,15 +22,20 @@ extern "C"
 
 #include "rmw/types.h"
 
+#define rmw_qos_deadline_default {0, 0}
+#define rmw_qos_lifespan_default {0, 0}
+#define rmw_qos_liveliness_lease_duration_default {0, 0}
+
 static const rmw_qos_profile_t rmw_qos_profile_sensor_data =
 {
   RMW_QOS_POLICY_HISTORY_KEEP_LAST,
   5,
   RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT,
   RMW_QOS_POLICY_DURABILITY_VOLATILE,
-  RMW_QOS_POLICY_DEADLINE_SYSTEM_DEFAULT,
+  rmw_qos_deadline_default,
+  rmw_qos_lifespan_default,
   RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT,
-  RMW_QOS_POLICY_LIFESPAN_SYSTEM_DEFAULT,
+  rmw_qos_liveliness_lease_duration_default,
   false
 };
 
@@ -40,9 +45,10 @@ static const rmw_qos_profile_t rmw_qos_profile_parameters =
   1000,
   RMW_QOS_POLICY_RELIABILITY_RELIABLE,
   RMW_QOS_POLICY_DURABILITY_VOLATILE,
-  RMW_QOS_POLICY_DEADLINE_SYSTEM_DEFAULT,
+  rmw_qos_deadline_default,
+  rmw_qos_lifespan_default,
   RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT,
-  RMW_QOS_POLICY_LIFESPAN_SYSTEM_DEFAULT,
+  rmw_qos_liveliness_lease_duration_default,
   false
 };
 
@@ -52,9 +58,10 @@ static const rmw_qos_profile_t rmw_qos_profile_default =
   10,
   RMW_QOS_POLICY_RELIABILITY_RELIABLE,
   RMW_QOS_POLICY_DURABILITY_VOLATILE,
-  RMW_QOS_POLICY_DEADLINE_SYSTEM_DEFAULT,
+  rmw_qos_deadline_default,
+  rmw_qos_lifespan_default,
   RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT,
-  RMW_QOS_POLICY_LIFESPAN_SYSTEM_DEFAULT,
+  rmw_qos_liveliness_lease_duration_default,
   false
 };
 
@@ -64,9 +71,10 @@ static const rmw_qos_profile_t rmw_qos_profile_services_default =
   10,
   RMW_QOS_POLICY_RELIABILITY_RELIABLE,
   RMW_QOS_POLICY_DURABILITY_VOLATILE,
-  RMW_QOS_POLICY_DEADLINE_SYSTEM_DEFAULT,
+  rmw_qos_deadline_default,
+  rmw_qos_lifespan_default,
   RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT,
-  RMW_QOS_POLICY_LIFESPAN_SYSTEM_DEFAULT,
+  rmw_qos_liveliness_lease_duration_default,
   false
 };
 
@@ -76,9 +84,10 @@ static const rmw_qos_profile_t rmw_qos_profile_parameter_events =
   1000,
   RMW_QOS_POLICY_RELIABILITY_RELIABLE,
   RMW_QOS_POLICY_DURABILITY_VOLATILE,
-  RMW_QOS_POLICY_DEADLINE_SYSTEM_DEFAULT,
+  rmw_qos_deadline_default,
+  rmw_qos_lifespan_default,
   RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT,
-  RMW_QOS_POLICY_LIFESPAN_SYSTEM_DEFAULT,
+  rmw_qos_liveliness_lease_duration_default,
   false
 };
 
@@ -88,9 +97,10 @@ static const rmw_qos_profile_t rmw_qos_profile_system_default =
   RMW_QOS_POLICY_DEPTH_SYSTEM_DEFAULT,
   RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT,
   RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT,
-  RMW_QOS_POLICY_DEADLINE_SYSTEM_DEFAULT,
+  rmw_qos_deadline_default,
+  rmw_qos_lifespan_default,
   RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT,
-  RMW_QOS_POLICY_LIFESPAN_SYSTEM_DEFAULT,
+  rmw_qos_liveliness_lease_duration_default,
   false
 };
 

--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -226,25 +226,12 @@ enum RMW_PUBLIC_TYPE rmw_qos_durability_policy_t
   RMW_QOS_POLICY_DURABILITY_VOLATILE
 };
 
-enum RMW_PUBLIC_TYPE rmw_qos_deadline_policy_t
-{
-  RMW_QOS_POLICY_DEADLINE_SYSTEM_DEFAULT,
-  RMW_QOS_POLICY_DEADLINE_TRANSIENT_LOCAL,
-  RMW_QOS_POLICY_DEADLINE_VOLATILE
-};
-
-enum RMW_PUBLIC_TYPE rmw_qos_liveliness_policy_t
+enum RMW_PUBLIC_TYPE rmw_qos_liveliness_policy_kind_t
 {
   RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT,
-  RMW_QOS_POLICY_LIVELINESS_TRANSIENT_LOCAL,
-  RMW_QOS_POLICY_LIVELINESS_VOLATILE
-};
-
-enum RMW_PUBLIC_TYPE rmw_qos_lifespan_policy_t
-{
-  RMW_QOS_POLICY_LIFESPAN_SYSTEM_DEFAULT,
-  RMW_QOS_POLICY_LIFESPAN_TRANSIENT_LOCAL,
-  RMW_QOS_POLICY_LIFESPAN_VOLATILE
+  RMW_QOS_POLICY_LIVELINESS_AUTOMATIC,
+  RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_PARTICIPANT,
+  RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC
 };
 
 /// ROS MiddleWare quality of service profile.
@@ -256,9 +243,11 @@ typedef struct RMW_PUBLIC_TYPE rmw_qos_profile_t
 
   enum rmw_qos_reliability_policy_t reliability;
   enum rmw_qos_durability_policy_t durability;
-  enum rmw_qos_deadline_policy_t deadline;
-  enum rmw_qos_liveliness_policy_t liveliness;
-  enum rmw_qos_lifespan_policy_t lifespan;
+  struct rmw_time_t deadline;
+  struct rmw_time_t lifespan;
+
+  enum rmw_qos_liveliness_policy_kind_t liveliness;
+  struct rmw_time_t liveliness_lease_duration;
 
   /// If true, any ROS specific namespacing conventions will be circumvented.
   /**


### PR DESCRIPTION
Signed-off-by: Emerson Knapp <eknapp@amazon.com>

*Issue #, if available:*

*Description of changes:*
Change the rmw qos policy types to reflect the actual settings that we are using for QoS

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
